### PR TITLE
changing default behavior so the containerId is the first parameter. …

### DIFF
--- a/client/src/main/groovy/de/gesellix/docker/client/DockerClientImpl.groovy
+++ b/client/src/main/groovy/de/gesellix/docker/client/DockerClientImpl.groovy
@@ -885,8 +885,13 @@ class DockerClientImpl implements DockerClient {
     commit(container, query, config = [:]) {
         log.info "docker commit"
 
-        def finalQuery = query ?: [:]
+        def finalQuery = [:]
         finalQuery.container = container
+        finalQuery.repo = query.repo
+        finalQuery.tag = query.tag
+		finalQuery.author = query.author
+		finalQuery.comment = query.comment
+		finalQuery.changes = query.changes
 
         config = config ?: [:]
 

--- a/client/src/main/groovy/de/gesellix/docker/client/DockerClientImpl.groovy
+++ b/client/src/main/groovy/de/gesellix/docker/client/DockerClientImpl.groovy
@@ -891,7 +891,7 @@ class DockerClientImpl implements DockerClient {
         finalQuery.tag = query.tag
 		finalQuery.author = query.author
 		finalQuery.comment = query.comment
-		finalQuery.changes = query.changes
+		//finalQuery.changes = query.changes
 
         config = config ?: [:]
 


### PR DESCRIPTION
Hi Tobias Gesellchen,

I'm trying to extend the gradle-docker-plugin proejct to expose the `docker commit` docker command. I couldn't get the command to work out of the box. It seems to be very important for the Docker client to have the container Id as the first parameter in the /commit request.

I changed the default behaviour of the DockerClient.commit method to always add the container id as the first URI parameter.

Best Regards
Tue