### PR TITLE
Stack deploy improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /classes
 npipe.exe
 .DS_Store
+out/

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'jacoco'
 //apply plugin: 'net.saliman.cobertura'
 //apply plugin: 'com.github.kt3k.coveralls'
 
+apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
@@ -79,6 +80,14 @@ jacocoTestReport.reports {
 
 artifacts {
     archives sourcesJar
+}
+
+install {
+    repositories.mavenInstaller {
+        pom.groupId = 'de.gesellix'
+        pom.artifactId = 'docker-client'
+        pom.version = '1.0.0-SNAPSHOT'
+    }
 }
 
 publishing {

--- a/client/src/main/groovy/de/gesellix/docker/client/stack/DeployConfigReader.groovy
+++ b/client/src/main/groovy/de/gesellix/docker/client/stack/DeployConfigReader.groovy
@@ -50,9 +50,14 @@ class DeployConfigReader {
         this.dockerClient = dockerClient
     }
 
-    // TODO test me
+    @Deprecated
     def loadCompose(String namespace, InputStream composeFile, String workingDir) {
-        ComposeConfig composeConfig = composeFileReader.load(composeFile, workingDir, System.getenv())
+        loadCompose(namespace, composeFile, workingDir, System.getenv())
+    }
+
+    // TODO test me
+    def loadCompose(String namespace, InputStream composeFile, String workingDir, Map<String, String> environment) {
+        ComposeConfig composeConfig = composeFileReader.load(composeFile, workingDir, environment)
         log.info("composeContent: $composeConfig}")
 
         List<String> serviceNetworkNames = composeConfig.services.collect { String name, de.gesellix.docker.compose.types.StackService service ->
@@ -547,7 +552,7 @@ class DeployConfigReader {
                 if (replicas) {
                     throw new IllegalArgumentException("replicas can only be used with replicated mode")
                 }
-                return [global: true]
+                return [global: [:]]
 
             case null:
             case "":

--- a/client/src/test/groovy/de/gesellix/docker/client/stack/DeployConfigReaderTest.groovy
+++ b/client/src/test/groovy/de/gesellix/docker/client/stack/DeployConfigReaderTest.groovy
@@ -178,7 +178,7 @@ class DeployConfigReaderTest extends Specification {
         reader.serviceMode(mode, replicas) == serviceMode
         where:
         mode         | replicas || serviceMode
-        "global"     | null     || [global: true]
+        "global"     | null     || [global: [:]]
         null         | null     || [replicated: [replicas: 1]]
         ""           | null     || [replicated: [replicas: 1]]
         "replicated" | null     || [replicated: [replicas: 1]]

--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerClientImplIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerClientImplIntegrationSpec.groovy
@@ -98,10 +98,10 @@ class DockerClientImplIntegrationSpec extends Specification {
         def version = dockerClient.version().content
 
         then:
-        def nonMatchingEntries = CONSTANTS.versionDetails.findResults { key, matcher ->
-            !matcher(version[key]) ? [(key): version[key]] : null
+        def missingKeys = CONSTANTS.versionDetails.findResults { key, matcher ->
+            !version[key] ? (key) : null
         }
-        nonMatchingEntries.empty
+        missingKeys.empty
     }
 
     def auth() {

--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerDistributionIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerDistributionIntegrationSpec.groovy
@@ -22,18 +22,11 @@ class DockerDistributionIntegrationSpec extends Specification {
 
         then:
         alpineDescriptor.status.code == 200
-        alpineDescriptor.content == [
-                Descriptor: [
-                        mediaType: "application/vnd.docker.distribution.manifest.list.v2+json",
-                        digest   : "sha256:2b796ae57cb164a11ce4dcc9e62a9ad10b64b38c4cc9748e456b5c11a19dc0f3",
-                        size     : 433
-                ],
-                Platforms : [
-                        [
-                                architecture: "amd64",
-                                os          : "linux"
-                        ]
-                ]
+        alpineDescriptor.content.Descriptor.mediaType == "application/vnd.docker.distribution.manifest.list.v2+json"
+        alpineDescriptor.content.Descriptor.digest =~ "sha256:[a-f0-9]{64}"
+        alpineDescriptor.content.Descriptor.size =~ "\\d{3,4}"
+        alpineDescriptor.content.Platforms == [
+                [architecture: "amd64", os: "linux"]
         ]
     }
 
@@ -44,21 +37,17 @@ class DockerDistributionIntegrationSpec extends Specification {
 
         then:
         debianDescriptor.status.code == 200
-        debianDescriptor.content == [
-                Descriptor: [
-                        mediaType: "application/vnd.docker.distribution.manifest.list.v2+json",
-                        digest   : "sha256:5fafd38cdee6c7e6b97356092b97389faa0aa069595f1c3cc3344428b5fd2339",
-                        size     : 2364
-                ],
-                Platforms : [
-                        [architecture: "amd64", os: "linux"],
-                        [architecture: "arm", os: "linux", variant: "v5"],
-                        [architecture: "arm", os: "linux", variant: "v7"],
-                        [architecture: "arm64", os: "linux", variant: "v8"],
-                        [architecture: "386", os: "linux"],
-                        [architecture: "ppc64le", os: "linux"],
-                        [architecture: "s390x", os: "linux"]
-                ]
+        debianDescriptor.content.Descriptor.mediaType == "application/vnd.docker.distribution.manifest.list.v2+json"
+        debianDescriptor.content.Descriptor.digest =~ "sha256:[a-f0-9]{64}"
+        debianDescriptor.content.Descriptor.size =~ "\\d{3,4}"
+        debianDescriptor.content.Platforms == [
+                [architecture: "amd64", os: "linux"],
+                [architecture: "arm", os: "linux", variant: "v5"],
+                [architecture: "arm", os: "linux", variant: "v7"],
+                [architecture: "arm64", os: "linux", variant: "v8"],
+                [architecture: "386", os: "linux"],
+                [architecture: "ppc64le", os: "linux"],
+                [architecture: "s390x", os: "linux"]
         ]
     }
 }

--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerStackComposeIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerStackComposeIntegrationSpec.groovy
@@ -1,0 +1,112 @@
+package de.gesellix.docker.client
+
+import de.gesellix.docker.client.stack.DeployConfigReader
+import de.gesellix.docker.client.stack.DeployStackOptions
+import groovy.util.logging.Slf4j
+import spock.lang.Requires
+import spock.lang.Specification
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+@Slf4j
+@Requires({ LocalDocker.available() && LocalDocker.supportsStack() })
+class DockerStackComposeIntegrationSpec extends Specification {
+
+    static DockerClient dockerClient
+    static Path composeFilePath
+
+    def setupSpec() {
+        dockerClient = new DockerClientImpl()
+        composeFilePath = Paths.get(getClass().getResource('compose/docker-stack.yml').toURI())
+        performSilently { dockerClient.leaveSwarm([force: true]) }
+    }
+
+    def cleanup() {
+        Thread.sleep(1000)
+    }
+
+    def "deploy a new stack with compose file"() {
+        given:
+        dockerClient.initSwarm()
+
+        def composeStream = composeFilePath.toFile().newInputStream()
+        def environment = [IMAGE_VERSION: '3.4', SOME_VAR: 'some-value']
+        def namespace = "new-stack"
+        def options = new DeployStackOptions()
+        def workingDir = composeFilePath.parent.toString()
+        def config = new DeployConfigReader(dockerClient).loadCompose(namespace, composeStream, workingDir, environment)
+
+        when:
+        dockerClient.stackDeploy(namespace, config, options)
+
+        then:
+        def tasks = delay { dockerClient.stackPs(namespace).content }
+        tasks.size() == config.services.size()
+
+        def spec = dockerClient.inspectService("${namespace}_service").content.Spec
+        def containerSpec = spec.TaskTemplate.ContainerSpec
+
+        spec.EndpointSpec == [Mode: 'vip']
+        spec.Labels == ['com.docker.stack.namespace': namespace]
+        spec.Mode == [Replicated: [Replicas: 1]]
+        spec.Name == "${namespace}_service"
+        spec.Networks.Aliases == [['service']]
+        spec.TaskTemplate.RestartPolicy == [
+                Condition: 'on-failure',
+                Delay: 5000000000,
+                MaxAttempts: 3,
+                Window: 120000000000
+        ]
+
+        containerSpec.Args == ['sh']
+        containerSpec.Env == ['SOME_VAR='+environment.SOME_VAR]
+        containerSpec.Image =~ "alpine:${environment.IMAGE_VERSION}(@sha256:[a-f0-9]{64})?"
+        containerSpec.Labels == ['com.docker.stack.namespace': namespace]
+        containerSpec.Mounts == [
+                [
+                        Type: 'volume',
+                        Source: namespace + '_shm',
+                        Target: '/dev/shm',
+                        VolumeOptions: [Labels: ['com.docker.stack.namespace': namespace]]
+                ]
+        ]
+
+        def networkInfo = delayAndRetrySilently { dockerClient.inspectNetwork("${namespace}_my-subnet") }
+        networkInfo.status.code == 200
+
+        def volumeInfo = delayAndRetrySilently { dockerClient.inspectVolume("${namespace}_shm") }
+        volumeInfo.status.code == 200
+
+        cleanup:
+        composeStream.close()
+        performSilently { dockerClient.stackRm(namespace) }
+        delayAndRetrySilently { dockerClient.rmVolume("${namespace}_shm") }
+        performSilently { dockerClient.leaveSwarm([force: true]) }
+    }
+
+    def performSilently(Closure action) {
+        try {
+            action()
+        } catch (Exception ignored) {
+        }
+    }
+
+    def delay(Integer secondsToWait = 1, Closure action) {
+        Thread.sleep(secondsToWait *1000)
+        action()
+    }
+
+    def delayAndRetrySilently(Integer secondsToWait = 1, Closure action, Integer retryCount = 5) {
+        Object retVal = null
+        for (_ in 1 .. retryCount) {
+            try {
+                Thread.sleep(secondsToWait *1000)
+                retVal = action()
+                break
+            } catch (Exception ignored) {}
+        }
+
+        retVal
+    }
+}

--- a/integration-test/src/test/resources/de/gesellix/docker/client/compose/docker-stack.yml
+++ b/integration-test/src/test/resources/de/gesellix/docker/client/compose/docker-stack.yml
@@ -1,0 +1,32 @@
+version: "3.3"
+services:
+  service:
+    image: alpine:${IMAGE_VERSION}
+    command: sh
+    deploy:
+      endpoint_mode: vip
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
+    environment:
+      SOME_VAR: ${SOME_VAR}
+    networks:
+      - "my-subnet"
+    volumes:
+      - type: volume
+        source: shm
+        target: /dev/shm
+
+networks:
+  my-subnet:
+
+volumes:
+  shm:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=128m


### PR DESCRIPTION
Hi Tobias,

While looking, in vain as it turned out, for docker engine API support for docker stack operations, in relation to a project at work, I stumbled across your client library, and have now been exploring it over the weekend.

I'm very impressed with your work - the organisation and clarity of the code, the extent of the API-coverage, the test coverage, and not least, your well-reasoned argument for implementing the client in a dynamically typed language.

To meet our requirements, I've made one minor change, fixed a bug, and slightly revised some tests to make them succeed locally.

An overview of the changes in the pull request, in order of importance:

1) Added a second loadCompose method to DeployConfigReader, to allow client code to directly pass in an environments Map (and thus avoiding polluting the environment of the client host/jvm in the process). This option lacks from the 'docker stack deploy' cli command, but it could be argued that this is an oversight, as it is possible to pass environment variables when creating services with 'docker service create --env').

2) Fixed a bug in the conversion of deploy.mode: global.

3) Revised integration test for import image from url, to not rely on the first network interface address (on my machine the first address was for a docker interface).

4) Revised integration test for 'docker version' to expect only a certain set of keys, not their values. In the wider perspective, as your client library finds more contributors, the expectations of integration tests should probably be more modest, to allow for some diversity in development platforms/docker versions.

5) Revised integration test for distribution image descriptor, in the same vein.

6) Added (starting point for) integration test for 'docker stack deploy -c'. The idea was to have more of an end-to-end test, with docker-stack.yml inlined in the test class to make it easy to see what is verified, and to expand it with as many supported compose options/keys as possible. I don't know if this is the right approach, maybe to start with because the test will grow large. Anyway, a means in some form of verifying that all compose file stack options, fit together in a complete stack description, produces the expected deployed services, networks and volumes, etc, would be useful.

7) Added gradle install task (maven plugin), for installing SNAPSHOT version of client library to local maven repo - purely a convenience in our setting, for fast turn-around with locally built client library used by our maven-based application.   


Best regards,
Nicholas