### PR TITLE
Problem when pushing with server and / in name

### DIFF
--- a/client/src/main/groovy/de/gesellix/docker/client/image/ManageImageClient.groovy
+++ b/client/src/main/groovy/de/gesellix/docker/client/image/ManageImageClient.groovy
@@ -240,7 +240,10 @@ class ManageImageClient implements ManageImage {
         }
         def repoAndTag = repositoryTagParser.parseRepositoryTag(actualImageName)
 
-        def response = client.post([path   : "/images/${repoAndTag.repo}/push".toString(),
+        def repo = URLEncoder.encode(repoAndTag.repo,"UTF-8").replace("/","%2f")
+
+        def response = client.post([path   : "/images/${repo}/push".toString(),
+                                    pathAlreadyEncoded: true,
                                     query  : [tag: repoAndTag.tag],
                                     headers: ["X-Registry-Auth": authBase64Encoded ?: "."]])
         responseHandler.ensureSuccessfulResponse(response, new IllegalStateException("docker push failed"))

--- a/client/src/test/groovy/de/gesellix/docker/client/image/ManageImageClientTest.groovy
+++ b/client/src/test/groovy/de/gesellix/docker/client/image/ManageImageClientTest.groovy
@@ -70,9 +70,10 @@ class ManageImageClientTest extends Specification {
         service.push("an-image")
 
         then:
-        1 * httpClient.post([path   : "/images/an-image/push",
-                             query  : [tag: ""],
-                             headers: ["X-Registry-Auth": "."]]) >> [status: [success: true]]
+        1 * httpClient.post([path              : "/images/an-image/push",
+                             query             : [tag: ""],
+                             pathAlreadyEncoded: true,
+                             headers           : ["X-Registry-Auth": "."]]) >> [status: [success: true]]
     }
 
     def "push with auth"() {
@@ -80,9 +81,10 @@ class ManageImageClientTest extends Specification {
         service.push("an-image:a-tag", "some-base64-encoded-auth")
 
         then:
-        1 * httpClient.post([path   : "/images/an-image/push",
-                             query  : [tag: "a-tag"],
-                             headers: ["X-Registry-Auth": "some-base64-encoded-auth"]]) >> [status: [success: true]]
+        1 * httpClient.post([path              : "/images/an-image/push",
+                             query             : [tag: "a-tag"],
+                             pathAlreadyEncoded: true,
+                             headers           : ["X-Registry-Auth": "some-base64-encoded-auth"]]) >> [status: [success: true]]
     }
 
     def "push with registry"() {
@@ -92,11 +94,12 @@ class ManageImageClientTest extends Specification {
         then:
         1 * httpClient.post([path : "/images/an-image/tag",
                              query: [repo: "registry:port/an-image",
-                                     tag : ""]])
+                             tag  : ""]])
         then:
-        1 * httpClient.post([path   : "/images/registry:port/an-image/push",
-                             query  : [tag: ""],
-                             headers: ["X-Registry-Auth": "."]]) >> [status: [success: true]]
+        1 * httpClient.post([path              : "/images/registry%3Aport%2Fan-image/push",
+                             query             : [tag: ""],
+                             pathAlreadyEncoded: true,
+                             headers           : ["X-Registry-Auth": "."]]) >> [status: [success: true]]
     }
 
     def "pull with defaults"() {


### PR DESCRIPTION
## Problem
When pushing name with slashes(/) isn't encoded so URL to the server is wrong.

```Java
DockerClient.push("project/test",null,"test.podal.se")
```
Will result in a `POST:http://<HOST>/images/test.podal.se/project/test/push`
The Docker API need: `/images/{name}/push`
To make this work it should be `http://<HOST>/images/test.podal.se%2Fproject%2Ftest/push`

## The Fix
Let push do the server encoding instead of _OkHttp_

## Prerequisite
This fix use `pathAlreadyEncoded:true` and it's added in _docker-engien_ pull request: Be able to exclude path url encoding #1
