### PR TITLE
change to localhost as advertise-addr for swarm-based tests

### DIFF
--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerNetworkIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerNetworkIntegrationSpec.groovy
@@ -1,6 +1,6 @@
 package de.gesellix.docker.client
 
-import de.gesellix.docker.testutil.NetworkInterfaces
+import de.gesellix.docker.testutil.SwarmUtil
 import groovy.util.logging.Slf4j
 import spock.lang.Requires
 import spock.lang.Specification
@@ -52,8 +52,8 @@ class DockerNetworkIntegrationSpec extends Specification {
     performSilently { dockerClient.leaveSwarm([force: true]) }
     !dockerClient.networks().content.find { it.Name == "test-net" }
     dockerClient.initSwarm([
-        "AdvertiseAddr"  : new NetworkInterfaces().getFirstInet4Address(),
-        "ListenAddr"     : "0.0.0.0:4500",
+        "AdvertiseAddr"  : new SwarmUtil().getAdvertiseAddr(),
+        "ListenAddr"     : "0.0.0.0",
         "ForceNewCluster": false
     ])
 

--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerServiceConfigIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerServiceConfigIntegrationSpec.groovy
@@ -1,6 +1,6 @@
 package de.gesellix.docker.client
 
-import de.gesellix.docker.testutil.NetworkInterfaces
+import de.gesellix.docker.testutil.SwarmUtil
 import groovy.util.logging.Slf4j
 import spock.lang.Requires
 import spock.lang.Specification
@@ -15,7 +15,7 @@ class DockerServiceConfigIntegrationSpec extends Specification {
 
   def setupSpec() {
     dockerClient = new DockerClientImpl()
-    swarmAdvertiseAddr = new NetworkInterfaces().getFirstInet4Address()
+    swarmAdvertiseAddr = new SwarmUtil().getAdvertiseAddr()
     performSilently { dockerClient.leaveSwarm([force: true]) }
   }
 

--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerServiceSecretIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerServiceSecretIntegrationSpec.groovy
@@ -1,6 +1,6 @@
 package de.gesellix.docker.client
 
-import de.gesellix.docker.testutil.NetworkInterfaces
+import de.gesellix.docker.testutil.SwarmUtil
 import groovy.util.logging.Slf4j
 import spock.lang.Requires
 import spock.lang.Specification
@@ -15,7 +15,7 @@ class DockerServiceSecretIntegrationSpec extends Specification {
 
   def setupSpec() {
     dockerClient = new DockerClientImpl()
-    swarmAdvertiseAddr = new NetworkInterfaces().getFirstInet4Address()
+    swarmAdvertiseAddr = new SwarmUtil().getAdvertiseAddr()
     performSilently { dockerClient.leaveSwarm([force: true]) }
   }
 

--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerStackComposeIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerStackComposeIntegrationSpec.groovy
@@ -2,7 +2,7 @@ package de.gesellix.docker.client
 
 import de.gesellix.docker.client.stack.DeployConfigReader
 import de.gesellix.docker.client.stack.DeployStackOptions
-import de.gesellix.docker.testutil.NetworkInterfaces
+import de.gesellix.docker.testutil.SwarmUtil
 import groovy.util.logging.Slf4j
 import spock.lang.Requires
 import spock.lang.Specification
@@ -21,7 +21,7 @@ class DockerStackComposeIntegrationSpec extends Specification {
   def setupSpec() {
     dockerClient = new DockerClientImpl()
     composeFilePath = Paths.get(getClass().getResource('compose/docker-stack.yml').toURI())
-    swarmAdvertiseAddr = new NetworkInterfaces().getFirstInet4Address()
+    swarmAdvertiseAddr = new SwarmUtil().getAdvertiseAddr()
     performSilently { dockerClient.leaveSwarm([force: true]) }
   }
 

--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerStackIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerStackIntegrationSpec.groovy
@@ -4,7 +4,7 @@ import de.gesellix.docker.client.stack.DeployStackConfig
 import de.gesellix.docker.client.stack.DeployStackOptions
 import de.gesellix.docker.client.stack.ManageStackClient
 import de.gesellix.docker.client.stack.types.StackService
-import de.gesellix.docker.testutil.NetworkInterfaces
+import de.gesellix.docker.testutil.SwarmUtil
 import groovy.util.logging.Slf4j
 import spock.lang.Requires
 import spock.lang.Specification
@@ -20,7 +20,7 @@ class DockerStackIntegrationSpec extends Specification {
   def setupSpec() {
     dockerClient = new DockerClientImpl()
 //        dockerClient.config.apiVersion = "v1.24"
-    swarmAdvertiseAddr = new NetworkInterfaces().getFirstInet4Address()
+    swarmAdvertiseAddr = new SwarmUtil().getAdvertiseAddr()
     performSilently { dockerClient.leaveSwarm([force: true]) }
   }
 

--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerSwarmIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerSwarmIntegrationSpec.groovy
@@ -1,6 +1,6 @@
 package de.gesellix.docker.client
 
-import de.gesellix.docker.testutil.NetworkInterfaces
+import de.gesellix.docker.testutil.SwarmUtil
 import groovy.util.logging.Slf4j
 import net.jodah.failsafe.Failsafe
 import net.jodah.failsafe.RetryPolicy
@@ -26,7 +26,7 @@ class DockerSwarmIntegrationSpec extends Specification {
   def setupSpec() {
     dockerClient = new DockerClientImpl()
 //        dockerClient.config.apiVersion = "v1.24"
-    swarmAdvertiseAddr = new NetworkInterfaces().getFirstInet4Address()
+    swarmAdvertiseAddr = new SwarmUtil().getAdvertiseAddr()
     performSilently { dockerClient.leaveSwarm([force: true]) }
   }
 

--- a/integration-test/src/test/groovy/de/gesellix/docker/testutil/SwarmUtil.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/testutil/SwarmUtil.groovy
@@ -1,0 +1,13 @@
+package de.gesellix.docker.testutil
+
+class SwarmUtil {
+
+  String getAdvertiseAddr(){
+    return "127.0.0.1"
+//    return new NetworkInterfaces().getFirstInet4Address()
+  }
+
+  String getListenAddr(){
+    return "0.0.0.0"
+  }
+}


### PR DESCRIPTION
resolves issues with ip addresses not being visible on docker for windows where the host and the wsl/hyper-v engine don't share a common interface