### PR TITLE
Require okio >= 3.x

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -46,10 +46,15 @@ dependencies {
         prefer("4.9.3")
       }
     }
-    implementation("com.squareup.okio:okio") {
-      version {
-        strictly("[2.5,4)")
-        prefer("3.1.0")
+    listOf(
+      "com.squareup.okio:okio",
+      "com.squareup.okio:okio-jvm"
+    ).onEach {
+      implementation(it) {
+        version {
+          strictly("[3,4)")
+          prefer("3.1.0")
+        }
       }
     }
     listOf(
@@ -101,7 +106,7 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.36")
   testImplementation("ch.qos.logback:logback-classic:[1.2,2)!!1.2.11")
 
-  implementation("com.squareup.okio:okio:3.1.0")
+  implementation("com.squareup.okio:okio-jvm:3.1.0")
   api("com.squareup.okhttp3:okhttp:4.9.3")
   testImplementation("com.squareup.okhttp3:mockwebserver:[4,5)")
 

--- a/explore/build.gradle.kts
+++ b/explore/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     }
     implementation("com.squareup.okio:okio") {
       version {
-        strictly("[2.5,4)")
+        strictly("[3,4)")
       }
     }
     listOf(

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     }
     implementation("com.squareup.okio:okio") {
       version {
-        strictly("[2,4)")
+        strictly("[3,4)")
       }
     }
     implementation("com.squareup.moshi:moshi") {


### PR DESCRIPTION
Explicitly using okio-jvm makes the artifacts Maven-compatible.

Relates to https://github.com/gesellix/docker-client/issues/245