### PR TITLE
Use data type long instead of int for HealthConfig

### DIFF
--- a/client/src/main/groovy/de/gesellix/docker/client/stack/DeployConfigReader.groovy
+++ b/client/src/main/groovy/de/gesellix/docker/client/stack/DeployConfigReader.groovy
@@ -400,8 +400,8 @@ class DeployConfigReader {
 
     return new HealthConfig(
         healthcheck.test.parts,
-        interval?.intValue() ?: 0,
-        timeout?.intValue() ?: 0,
+        interval ?: 0,
+        timeout ?: 0,
         retries,
         null
     )

--- a/client/src/test/groovy/de/gesellix/docker/client/stack/DeployConfigReaderTest.groovy
+++ b/client/src/test/groovy/de/gesellix/docker/client/stack/DeployConfigReaderTest.groovy
@@ -556,8 +556,8 @@ class DeployConfigReaderTest extends Specification {
         retries: 10
     )) == new HealthConfig(
         ["EXEC", "touch", "/foo"],
-        Duration.of(2, ChronoUnit.MILLIS).toNanos().intValue(),
-        Duration.of(30, ChronoUnit.SECONDS).toNanos().intValue(),
+        Duration.of(2, ChronoUnit.MILLIS).toNanos().longValue(),
+        Duration.of(30, ChronoUnit.SECONDS).toNanos().longValue(),
         10,
         null
     )


### PR DESCRIPTION
Relates to https://github.com/docker-client/docker-remote-api/pull/71