### PR TITLE
Revert "Bump byte-buddy from 1.12.12 to 1.12.13"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 val dependencyVersions = listOf(
   "com.squareup.okio:okio-jvm:3.2.0",
-  "net.bytebuddy:byte-buddy:1.12.13",
+  "net.bytebuddy:byte-buddy:1.12.12",
   "org.codehaus.groovy:groovy:3.0.12",
   "org.jetbrains:annotations:23.0.0",
 )


### PR DESCRIPTION
Reverts gesellix/docker-client#350 due to https://github.com/joke/spock-mockable/issues/208, which relates to https://github.com/raphw/byte-buddy/issues/1297.