### PR TITLE
remove logging from waitForLogEvent

### DIFF
--- a/client/src/main/groovy/de/gesellix/docker/client/container/ManageContainerClient.groovy
+++ b/client/src/main/groovy/de/gesellix/docker/client/container/ManageContainerClient.groovy
@@ -350,7 +350,6 @@ class ManageContainerClient implements ManageContainer {
 
       @Override
       void onNext(Frame element) {
-        log.info(element?.toString())
         if (matcher.test(element)) {
           latch.countDown()
         }

--- a/integration-test/src/test/groovy/de/gesellix/docker/client/DockerContainerIntegrationSpec.groovy
+++ b/integration-test/src/test/groovy/de/gesellix/docker/client/DockerContainerIntegrationSpec.groovy
@@ -856,6 +856,7 @@ class DockerContainerIntegrationSpec extends Specification {
 
       @Override
       boolean test(Frame frame) {
+        log.info(frame?.toString())
         def matches = frame.streamType == Frame.StreamType.STDOUT && frame.payloadAsString.contains("Listening and serving HTTP")
         matcherMatched = matcherMatched || matches
         return matches


### PR DESCRIPTION
... so that the client can control log output.

The `waitForLogEvent` method is very convenient, however it creates a lot of log spam, that makes it hard to find problems. We would prefer to only use our own logging so where we can control the format and filter out messages if we want to.