### PR TITLE
Don't call "/info" API endpoint to get default registry

### DIFF
--- a/client/src/main/groovy/de/gesellix/docker/client/authentication/ManageAuthenticationClient.groovy
+++ b/client/src/main/groovy/de/gesellix/docker/client/authentication/ManageAuthenticationClient.groovy
@@ -27,7 +27,7 @@ class ManageAuthenticationClient implements ManageAuthentication {
     this.client = client
     this.authConfigReader = authConfigReader
     this.dockerConfigReader = dockerConfigReader
-    this.registryElection = new RegistryElection(client.getSystemApi(), authConfigReader)
+    this.registryElection = new RegistryElection(authConfigReader)
   }
 
   @Override

--- a/client/src/main/java/de/gesellix/docker/client/authentication/RegistryElection.java
+++ b/client/src/main/java/de/gesellix/docker/client/authentication/RegistryElection.java
@@ -3,20 +3,12 @@ package de.gesellix.docker.client.authentication;
 import de.gesellix.docker.authentication.AuthConfig;
 import de.gesellix.docker.authentication.AuthConfigReader;
 import de.gesellix.docker.engine.DockerEnv;
-import de.gesellix.docker.remote.api.SystemInfo;
-import de.gesellix.docker.remote.api.client.SystemApi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RegistryElection {
 
-  private static final Logger log = LoggerFactory.getLogger(RegistryElection.class);
-
-  private final SystemApi systemApi;
   private final AuthConfigReader authConfigReader;
 
-  public RegistryElection(SystemApi systemApi, AuthConfigReader authConfigReader) {
-    this.systemApi = systemApi;
+  public RegistryElection(AuthConfigReader authConfigReader) {
     this.authConfigReader = authConfigReader;
   }
 
@@ -36,24 +28,5 @@ public class RegistryElection {
   public String electAuthServer() {
     final String defaultServerAddress = new DockerEnv().getIndexUrl_v1();
     return defaultServerAddress;
-
-    // deprecated/obsolete: see https://github.com/docker/cli/pull/2819 for details
-    //
-    // The daemon `/info` endpoint informs us of the default registry being
-    // used. This is essential in cross-platforms environment, where for
-    // example a Linux client might be interacting with a Windows daemon, hence
-    // the default registry URL might be Windows specific.
-//    try {
-//      SystemInfo info = systemApi.systemInfo();
-//      if (info == null || info.getIndexServerAddress() == null || info.getIndexServerAddress().isEmpty()) {
-//        log.warn("Empty registry endpoint from daemon. Using system default: " + defaultServerAddress);
-//        return defaultServerAddress;
-//      } else {
-//        return info.getIndexServerAddress();
-//      }
-//    } catch (Exception e) {
-//      log.warn("Failed to get default registry endpoint from daemon. Using system default: " + defaultServerAddress, e);
-//      return defaultServerAddress;
-//    }
   }
 }

--- a/client/src/main/java/de/gesellix/docker/client/authentication/RegistryElection.java
+++ b/client/src/main/java/de/gesellix/docker/client/authentication/RegistryElection.java
@@ -32,25 +32,28 @@ public class RegistryElection {
     return authConfigReader.readAuthConfig(configKey, null);
   }
 
-  // ElectAuthServer returns the default registry to use (by asking the daemon)
+  // ElectAuthServer returns the default registry to use
   public String electAuthServer() {
+    final String defaultServerAddress = new DockerEnv().getIndexUrl_v1();
+    return defaultServerAddress;
+
+    // deprecated/obsolete: see https://github.com/docker/cli/pull/2819 for details
+    //
     // The daemon `/info` endpoint informs us of the default registry being
     // used. This is essential in cross-platforms environment, where for
     // example a Linux client might be interacting with a Windows daemon, hence
     // the default registry URL might be Windows specific.
-    final String defaultServerAddress = new DockerEnv().getIndexUrl_v1();
-    try {
-      SystemInfo info = systemApi.systemInfo();
-      if (info == null || info.getIndexServerAddress() == null || info.getIndexServerAddress().isEmpty()) {
-        log.warn("Empty registry endpoint from daemon. Using system default: " + defaultServerAddress);
-      }
-      else {
-        return info.getIndexServerAddress();
-      }
-    }
-    catch (Exception e) {
-      log.warn("Failed to get default registry endpoint from daemon. Using system default: " + defaultServerAddress, e);
-    }
-    return defaultServerAddress;
+//    try {
+//      SystemInfo info = systemApi.systemInfo();
+//      if (info == null || info.getIndexServerAddress() == null || info.getIndexServerAddress().isEmpty()) {
+//        log.warn("Empty registry endpoint from daemon. Using system default: " + defaultServerAddress);
+//        return defaultServerAddress;
+//      } else {
+//        return info.getIndexServerAddress();
+//      }
+//    } catch (Exception e) {
+//      log.warn("Failed to get default registry endpoint from daemon. Using system default: " + defaultServerAddress, e);
+//      return defaultServerAddress;
+//    }
   }
 }

--- a/client/src/test/groovy/de/gesellix/docker/client/authentication/RegistryElectionTest.groovy
+++ b/client/src/test/groovy/de/gesellix/docker/client/authentication/RegistryElectionTest.groovy
@@ -4,6 +4,7 @@ import de.gesellix.docker.authentication.AuthConfig
 import de.gesellix.docker.authentication.AuthConfigReader
 import de.gesellix.docker.remote.api.SystemInfo
 import de.gesellix.docker.remote.api.client.SystemApi
+import spock.lang.Ignore
 import spock.lang.Specification
 
 class RegistryElectionTest extends Specification {
@@ -36,7 +37,7 @@ class RegistryElectionTest extends Specification {
     def actualConfig = election.resolveAuthConfig("official.registry", true)
 
     then:
-    1 * systemApi.systemInfo() >> { throw new RuntimeException("for-test") }
+//    1 * systemApi.systemInfo() >> { throw new RuntimeException("for-test") }
     1 * authConfigReader.readAuthConfig("https://index.docker.io/v1/", null) >> expectedConfig
     actualConfig == expectedConfig
   }
@@ -51,11 +52,12 @@ class RegistryElectionTest extends Specification {
     def actualConfig = election.resolveAuthConfig("official.registry", true)
 
     then:
-    1 * systemApi.systemInfo() >> systemInfo
+//    1 * systemApi.systemInfo() >> systemInfo
     1 * authConfigReader.readAuthConfig("https://index.docker.io/v1/", null) >> expectedConfig
     actualConfig == expectedConfig
   }
 
+  @Ignore("deprecated/obsolete: see https://github.com/docker/cli/pull/2819 for details")
   def "elects the platform's IndexServerAddress"() {
     given:
     def expectedConfig = new AuthConfig(username: "baz-foo")

--- a/client/src/test/groovy/de/gesellix/docker/client/authentication/RegistryElectionTest.groovy
+++ b/client/src/test/groovy/de/gesellix/docker/client/authentication/RegistryElectionTest.groovy
@@ -3,18 +3,15 @@ package de.gesellix.docker.client.authentication
 import de.gesellix.docker.authentication.AuthConfig
 import de.gesellix.docker.authentication.AuthConfigReader
 import de.gesellix.docker.remote.api.SystemInfo
-import de.gesellix.docker.remote.api.client.SystemApi
-import spock.lang.Ignore
 import spock.lang.Specification
 
 class RegistryElectionTest extends Specification {
 
   RegistryElection election
-  SystemApi systemApi = Mock(SystemApi)
   AuthConfigReader authConfigReader = Mock(AuthConfigReader)
 
   def setup() {
-    election = new RegistryElection(systemApi, authConfigReader)
+    election = new RegistryElection(authConfigReader)
   }
 
   def "leaves non-official index name unchanged"() {
@@ -37,7 +34,6 @@ class RegistryElectionTest extends Specification {
     def actualConfig = election.resolveAuthConfig("official.registry", true)
 
     then:
-//    1 * systemApi.systemInfo() >> { throw new RuntimeException("for-test") }
     1 * authConfigReader.readAuthConfig("https://index.docker.io/v1/", null) >> expectedConfig
     actualConfig == expectedConfig
   }
@@ -52,24 +48,7 @@ class RegistryElectionTest extends Specification {
     def actualConfig = election.resolveAuthConfig("official.registry", true)
 
     then:
-//    1 * systemApi.systemInfo() >> systemInfo
     1 * authConfigReader.readAuthConfig("https://index.docker.io/v1/", null) >> expectedConfig
-    actualConfig == expectedConfig
-  }
-
-  @Ignore("deprecated/obsolete: see https://github.com/docker/cli/pull/2819 for details")
-  def "elects the platform's IndexServerAddress"() {
-    given:
-    def expectedConfig = new AuthConfig(username: "baz-foo")
-    def systemInfo = Mock(SystemInfo)
-    systemInfo.indexServerAddress >> "platform.registry"
-
-    when:
-    def actualConfig = election.resolveAuthConfig("official.registry", true)
-
-    then:
-    1 * systemApi.systemInfo() >> systemInfo
-    1 * authConfigReader.readAuthConfig("platform.registry", null) >> expectedConfig
     actualConfig == expectedConfig
   }
 }


### PR DESCRIPTION
Relates to https://github.com/docker/cli/pull/2819
