### PR TITLE
Support both Groovy 3.x and Groovy 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,5 @@ updates:
       # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
       groovy:
         patterns:
+          - "org.codehaus.groovy:*"
           - "org.apache.groovy:*"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ val dependencyVersions = listOf(
   "net.bytebuddy:byte-buddy:1.14.9",
   "net.bytebuddy:byte-buddy-agent:1.14.9",
   "org.apache.commons:commons-compress:1.24.0",
+  "org.codehaus.groovy:groovy:3.0.19",
   "org.apache.groovy:groovy:4.0.15",
   "org.jetbrains:annotations:24.0.1",
   "org.junit:junit-bom:5.10.0",

--- a/client-groovy4/build.gradle.kts
+++ b/client-groovy4/build.gradle.kts
@@ -73,13 +73,13 @@ dependencies {
       }
     }
     listOf(
-        "org.codehaus.groovy:groovy",
-        "org.codehaus.groovy:groovy-json"
+        "org.apache.groovy:groovy",
+        "org.apache.groovy:groovy-json"
     ).onEach {
       implementation(it) {
         version {
-          strictly("[3,4)")
-          prefer("3.0.19")
+          strictly("[4,)")
+          prefer("4.0.15")
         }
       }
     }
@@ -103,8 +103,8 @@ dependencies {
   api("de.gesellix:docker-engine:2023-10-03T21-35-00")
   api("de.gesellix:docker-compose:2023-09-23T20-42-00")
 
-  implementation("org.codehaus.groovy:groovy:3.0.19")
-  implementation("org.codehaus.groovy:groovy-json:3.0.19")
+  implementation("org.apache.groovy:groovy:4.0.15")
+  implementation("org.apache.groovy:groovy-json:4.0.15")
 
   api("com.squareup.moshi:moshi:1.15.0")
   implementation("com.google.re2j:re2j:1.7")
@@ -118,12 +118,12 @@ dependencies {
 
   implementation("org.apache.commons:commons-compress:1.24.0")
 
-  implementation("org.bouncycastle:bcpkix-jdk18on:1.76")
+//  implementation("org.bouncycastle:bcpkix-jdk18on:1.76")
 
   testImplementation("de.gesellix:testutil:[2023-09-01T01-01-01,)")
 
   testImplementation("org.junit.platform:junit-platform-launcher:1.10.0")
-  testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
+  testImplementation("org.spockframework:spock-core:2.3-groovy-4.0")
   testRuntimeOnly("net.bytebuddy:byte-buddy:1.14.9")
   testRuntimeOnly("org.objenesis:objenesis:3.3")
   testImplementation("io.github.joke:spock-mockable:2.3.0")
@@ -134,6 +134,27 @@ dependencies {
 java {
   toolchain {
     languageVersion.set(JavaLanguageVersion.of(8))
+  }
+}
+
+java {
+  sourceSets {
+    main {
+      groovy {
+        srcDirs(project(":client").sourceSets["main"].allJava)
+      }
+      resources {
+        srcDirs(project(":client").sourceSets["main"].resources)
+      }
+    }
+    test {
+      groovy {
+        srcDirs(project(":client").sourceSets["test"].allJava)
+      }
+      resources {
+        srcDirs(project(":client").sourceSets["test"].resources)
+      }
+    }
   }
 }
 
@@ -209,7 +230,7 @@ publishing {
         }
       }
       artifactId = "docker-client"
-      version = artifactVersion
+      version = "${artifactVersion}-groovy-4"
       from(components["java"])
       artifact(sourcesJar.get())
       artifact(javadocJar.get())

--- a/explore/build.gradle.kts
+++ b/explore/build.gradle.kts
@@ -38,6 +38,17 @@ dependencies {
       }
     }
     listOf(
+        "org.codehaus.groovy:groovy",
+        "org.codehaus.groovy:groovy-json"
+    ).onEach {
+      implementation(it) {
+        version {
+          strictly("[3,4)")
+          prefer("3.0.19")
+        }
+      }
+    }
+    listOf(
       "org.apache.groovy:groovy",
       "org.apache.groovy:groovy-json"
     ).onEach {
@@ -49,13 +60,16 @@ dependencies {
       }
     }
   }
-  implementation(project(":client"))
+//  implementation(project(":client"))
+  implementation(project(":client-groovy4"))
+//  implementation("org.codehaus.groovy:groovy:[3,4)")
   implementation("org.apache.groovy:groovy:4.0.15")
   testImplementation("org.apache.commons:commons-compress:1.24.0")
 
   implementation("org.slf4j:slf4j-api:2.0.9")
   runtimeOnly("ch.qos.logback:logback-classic:[1.2,2)!!1.3.11")
 
+//  testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
   testImplementation("org.spockframework:spock-core:2.3-groovy-4.0")
   testRuntimeOnly("net.bytebuddy:byte-buddy:1.14.9")
   testRuntimeOnly("ch.qos.logback:logback-classic:[1.2,2)!!1.3.11")

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -75,7 +75,8 @@ dependencies {
     }
   }
   implementation(project(":client"))
-  testImplementation("org.apache.groovy:groovy-json:[4,)")
+  testImplementation("org.codehaus.groovy:groovy-json:[3,4)")
+//  testImplementation("org.apache.groovy:groovy-json:[4,)")
   testImplementation("com.kohlschutter.junixsocket:junixsocket-core:[2.4,)")
   testImplementation("com.kohlschutter.junixsocket:junixsocket-common:[2.4,)")
 
@@ -87,7 +88,8 @@ dependencies {
 
   testImplementation("de.gesellix:docker-registry:2023-10-03T20-58-00")
   testImplementation("de.gesellix:testutil:[2023-09-01T01-01-01,)")
-  testImplementation("org.spockframework:spock-core:2.3-groovy-4.0")
+  testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
+//  testImplementation("org.spockframework:spock-core:2.3-groovy-4.0")
   testRuntimeOnly("net.bytebuddy:byte-buddy:1.14.9")
   testImplementation("org.apache.commons:commons-lang3:3.13.0")
   testRuntimeOnly("ch.qos.logback:logback-classic:[1.2,2)!!1.3.8")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,9 @@
 rootProject.name = "docker-client"
-include("client", "integration-test", "explore")
+include(
+    "client",
+    "client-groovy4",
+    "integration-test",
+    "explore")
 
 // https://docs.gradle.org/8.0.1/userguide/toolchains.html#sub:download_repositories
 plugins {


### PR DESCRIPTION
We still have to support Gradle < 9.x, which requires Groovy 3.x

See https://github.com/gesellix/docker-client/issues/578
