### PR TITLE
Update constraint for groovy to match version

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
       implementation(it) {
         version {
           strictly("[3,4)")
-          prefer("3.0.21")
+          prefer("3.0.22")
         }
       }
     }


### PR DESCRIPTION
The constraint should match the current version of `groovy` and `groovy-json`, as defined in line 106 and 107, the current constraint causes unnecessary dependency conflicts.